### PR TITLE
Add support for sync messaging

### DIFF
--- a/network_manager/network_node/network_node_message_types.py
+++ b/network_manager/network_node/network_node_message_types.py
@@ -2,6 +2,5 @@ from enum import Enum
 
 
 class NetworkNodeMessageTypes(Enum):
-    MSG_RESPONSE = 1
-    REQUEST_CONNECTION = 2
-    ACCEPT_CONNECTION_REQUEST = 3
+    REQUEST_CONNECTION = 1
+    ACCEPT_CONNECTION_REQUEST = 2

--- a/swarm/message_types.py
+++ b/swarm/message_types.py
@@ -18,3 +18,4 @@ class MessageTypes(Enum):
     SYNC_INTERMEDIARIES = 14
     BOT_TEARDOWN = 15
     REQUEST_PATH_TO_BOT = 16
+    MSG_RESPONSE = 17

--- a/swarm_bot_test/test_swarm_bot_messaging.py
+++ b/swarm_bot_test/test_swarm_bot_messaging.py
@@ -1,0 +1,82 @@
+import logging
+import unittest
+
+from network_manager_test.network_node_test_class import NetworkNodeTestClass
+from swarm.swarm_bot import SwarmBot
+
+
+class TestSwarmBotMessaging(NetworkNodeTestClass):
+    def test_swarm_bot_can_send_asynchronous_messages_between_directly_connected_bots(self):
+        test_swarm_bot_1 = self.create_network_node(SwarmBot)
+        test_swarm_bot_2 = self.create_network_node(SwarmBot)
+
+        test_swarm_bot_1.startup()
+        test_swarm_bot_2.startup()
+
+        test_swarm_bot_1.connect_to_network_node(test_swarm_bot_2)
+
+        self.wait_for_idle_network()
+
+        msg_id = test_swarm_bot_1.send_directed_message(test_swarm_bot_2.get_id(), "TEST", {})
+
+        self.wait_for_idle_network()
+
+        self.assertTrue(test_swarm_bot_2.received_msg_with_id(msg_id))
+
+    def test_swarm_bot_can_send_synchronous_messages_between_directly_connected_bots(self):
+        test_swarm_bot_1 = self.create_network_node(SwarmBot)
+        test_swarm_bot_2 = self.create_network_node(SwarmBot)
+
+        test_swarm_bot_1.startup()
+        test_swarm_bot_2.startup()
+
+        test_swarm_bot_1.connect_to_network_node(test_swarm_bot_2)
+
+        self.wait_for_idle_network()
+
+        with self.assertRaises(Exception) as raised_error:
+            test_swarm_bot_1.send_sync_directed_message(test_swarm_bot_2.get_id(), "TEST", {})
+
+        self.assertIn("Did not receive message response within time limit", str(raised_error.exception))
+
+    def test_swarm_bot_can_send_asynchronous_messages_between_non_directly_connected_bots(self):
+        test_swarm_bot_1 = self.create_network_node(SwarmBot)
+        test_swarm_bot_2 = self.create_network_node(SwarmBot)
+        test_swarm_bot_3 = self.create_network_node(SwarmBot)
+
+        test_swarm_bot_1.startup()
+        test_swarm_bot_2.startup()
+        test_swarm_bot_3.startup()
+
+        test_swarm_bot_1.connect_to_network_node(test_swarm_bot_3)
+
+        self.wait_for_idle_network()
+
+        msg_id = test_swarm_bot_1.send_directed_message(test_swarm_bot_3.get_id(), "TEST", {})
+
+        self.wait_for_idle_network()
+
+        self.assertTrue(test_swarm_bot_3.received_msg_with_id(msg_id))
+
+    def test_swarm_bot_can_send_synchronous_messages_between_non_directly_connected_bots(self):
+        test_swarm_bot_1 = self.create_network_node(SwarmBot)
+        test_swarm_bot_2 = self.create_network_node(SwarmBot)
+        test_swarm_bot_3 = self.create_network_node(SwarmBot)
+
+        test_swarm_bot_1.startup()
+        test_swarm_bot_2.startup()
+        test_swarm_bot_3.startup()
+
+        test_swarm_bot_1.connect_to_network_node(test_swarm_bot_3)
+
+        self.wait_for_idle_network()
+
+        with self.assertRaises(Exception) as raised_error:
+            test_swarm_bot_1.send_sync_directed_message(test_swarm_bot_3.get_id(), "TEST", {})
+
+        self.assertIn("Did not receive message response within time limit", str(raised_error.exception))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()


### PR DESCRIPTION
- Moves original sync messaging framework from network node to swarm bot
- There is one method for sync messaging and one method for async messaging

https://github.com/users/BramSrna/projects/8/views/1?pane=issue&itemId=21419110

```
PS C:\Users\brams\Documents\Programming Projects\Swarm> .\windows_prepush_verification.ps1
0
0
======================================== test session starts ========================================
platform win32 -- Python 3.9.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: C:\Users\brams\Documents\Programming Projects\Swarm
collected 47 items

federated_learning_test\test_federated_learning.py s                                           [  2%]
network_manager_test\test_network_information_propagation.py .....                             [ 12%]
network_manager_test\test_network_manager.py .....                                             [ 23%]
network_manager_test\test_network_messaging.py ...                                             [ 29%]
network_manager_test\test_network_node.py ...                                                  [ 36%]
swarm_bot_test\test_full_connectivity_simulation.py ......                                     [ 48%]
swarm_bot_test\test_swarm_bot.py ..                                                            [ 53%]
swarm_bot_test\test_swarm_bot_messaging.py ....                                                [ 61%]
swarm_bot_test\test_swarm_bot_swarm_memory.py ..s                                              [ 68%]
swarm_bot_test\test_swarm_bot_task_bundle_interaction.py sssssssssss                           [ 91%]
swarm_bot_test\test_swarm_bot_task_inbox.py ..                                                 [ 95%]
swarm_bot_test\test_swarm_manager.py ss                                                        [100%]

============================ 32 passed, 15 skipped in 277.21s (0:04:37) =============================
PS C:\Users\brams\Documents\Programming Projects\Swarm>
```